### PR TITLE
Complete and type-safe library development

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,16 @@
 export { createSync } from './server/createSync';
 export { createClient } from './shared/createClient';
 export { createMemoryIdempotencyStore } from './shared/idempotency';
-export type { PrimaryKey, OrderBy, SelectWindow, IdempotencyStore } from './shared/types';
+export type {
+  PrimaryKey,
+  OrderBy,
+  SelectWindow,
+  IdempotencyStore,
+  DatabaseAdapter,
+  MutatorsSpec,
+  ServerMutatorsSpec,
+  ClientMutatorsFromServer,
+  AppTypes,
+  AppSchema,
+  AppMutators
+} from './shared/types';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,7 +52,16 @@ export type ClientMutators<TSpec extends MutatorsSpec> = {
 export function defineMutators<T extends MutatorsSpec>(spec: T): T { return spec; }
 
 // App-wide type augmentation hook. Libraries/apps can augment this interface via
-// `declare module 'just-sync' { interface AppTypes { Schema: any; Mutators: any } }`
-// to enable zero-generics client typing.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AppTypes { }
+// `declare module 'just-sync' { interface AppTypes { Schema: { users: User; ... }; Mutators: ... } }`
+// to enable zero-generics client typing. Properties are optional so that the library works without augmentation.
+export interface AppTypes {
+  Schema?: Record<string, Record<string, unknown>>;
+  Mutators?: ServerMutatorsSpec;
+}
+
+// Utility types for deriving table and row types from AppTypes['Schema'] when provided
+export type AppSchema = NonNullable<AppTypes['Schema']> extends Record<string, any> ? NonNullable<AppTypes['Schema']> : {};
+export type AppMutators = NonNullable<AppTypes['Mutators']> extends ServerMutatorsSpec ? NonNullable<AppTypes['Mutators']> : {};
+
+export type TableNames<TSchema> = TSchema extends Record<string, any> ? keyof TSchema : never;
+export type RowOf<TSchema, K> = K extends keyof TSchema ? TSchema[K] : Record<string, unknown>;


### PR DESCRIPTION
Enhance type safety and IntelliSense for `createClient` by introducing `AppTypes` for schema/mutator augmentation and re-exporting key types.

---
<a href="https://cursor.com/background-agent?bcId=bc-28561091-0840-4ce3-b47a-298f89a887e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28561091-0840-4ce3-b47a-298f89a887e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

